### PR TITLE
fix: tinny-secp256k1 interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ecpair",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "Client-side Bitcoin JavaScript library ECPair",
   "main": "./src/index.js",
-  "types": "./src/ecpair.d.ts",
+  "types": "./src/index.d.ts",
   "engines": {
     "node": ">=8.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ecpair",
   "version": "2.0.1",
   "description": "Client-side Bitcoin JavaScript library ECPair",
-  "main": "./src/ecpair.js",
+  "main": "./src/index.js",
   "types": "./src/ecpair.d.ts",
   "engines": {
     "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecpair",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Client-side Bitcoin JavaScript library ECPair",
   "main": "./src/ecpair.js",
   "types": "./src/ecpair.d.ts",

--- a/src/ecpair.d.ts
+++ b/src/ecpair.d.ts
@@ -40,7 +40,7 @@ export interface TinySecp256k1Interface {
     isPoint(p: Uint8Array): boolean;
     pointCompress(p: Uint8Array, compressed?: boolean): Uint8Array;
     isPrivate(d: Uint8Array): boolean;
-    pointFromScalar(d?: Uint8Array, compressed?: boolean): Uint8Array;
+    pointFromScalar(d: Uint8Array, compressed?: boolean): Uint8Array | null;
     sign(h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array;
     signSchnorr?(h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array;
     verify(h: Uint8Array, Q: Uint8Array, signature: Uint8Array, strict?: boolean): boolean;

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -83,8 +83,14 @@ function ECPairFactory(ecc) {
       return this.__D;
     }
     get publicKey() {
-      if (!this.__Q)
-        this.__Q = Buffer.from(ecc.pointFromScalar(this.__D, this.compressed));
+      if (!this.__Q) {
+        // @ts-ignore: it is not possible for both `__Q` and `__D` to be undefined.
+        // The factory methods guard for this.
+        const p = ecc.pointFromScalar(this.__D, this.compressed);
+        // @ts-ignore: it is not possible for `p` to be null.
+        // `fromPrivateKey()` checks that `__D` is a valid scalar
+        this.__Q = Buffer.from(p);
+      }
       return this.__Q;
     }
     toWIF() {

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -84,10 +84,10 @@ function ECPairFactory(ecc) {
     }
     get publicKey() {
       if (!this.__Q) {
-        // @ts-ignore: it is not possible for both `__Q` and `__D` to be `undefined` at the same time.
+        // It is not possible for both `__Q` and `__D` to be `undefined` at the same time.
         // The factory methods guard for this.
         const p = ecc.pointFromScalar(this.__D, this.compressed);
-        // @ts-ignore: it is not possible for `p` to be null.
+        // It is not possible for `p` to be null.
         // `fromPrivateKey()` checks that `__D` is a valid scalar.
         this.__Q = Buffer.from(p);
       }

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -84,11 +84,11 @@ function ECPairFactory(ecc) {
     }
     get publicKey() {
       if (!this.__Q) {
-        // @ts-ignore: it is not possible for both `__Q` and `__D` to be undefined.
+        // @ts-ignore: it is not possible for both `__Q` and `__D` to be `undefined` at the same time.
         // The factory methods guard for this.
         const p = ecc.pointFromScalar(this.__D, this.compressed);
         // @ts-ignore: it is not possible for `p` to be null.
-        // `fromPrivateKey()` checks that `__D` is a valid scalar
+        // `fromPrivateKey()` checks that `__D` is a valid scalar.
         this.__Q = Buffer.from(p);
       }
       return this.__Q;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export { ECPairFactory as default, ECPairFactory, Signer, SignerAsync, ECPairAPI, ECPairInterface, TinySecp256k1Interface, } from './ecpair';
+export { ECPairFactory as default, ECPairFactory, Signer, SignerAsync, ECPairAPI, ECPairInterface, TinySecp256k1Interface, networks, } from './ecpair';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
-exports.ECPairFactory = exports.default = void 0;
+exports.networks = exports.ECPairFactory = exports.default = void 0;
 var ecpair_1 = require('./ecpair');
 Object.defineProperty(exports, 'default', {
   enumerable: true,
@@ -12,5 +12,11 @@ Object.defineProperty(exports, 'ECPairFactory', {
   enumerable: true,
   get: function () {
     return ecpair_1.ECPairFactory;
+  },
+});
+Object.defineProperty(exports, 'networks', {
+  enumerable: true,
+  get: function () {
+    return ecpair_1.networks;
   },
 });

--- a/ts_src/ecpair.ts
+++ b/ts_src/ecpair.ts
@@ -56,7 +56,7 @@ export interface TinySecp256k1Interface {
   isPoint(p: Uint8Array): boolean;
   pointCompress(p: Uint8Array, compressed?: boolean): Uint8Array;
   isPrivate(d: Uint8Array): boolean;
-  pointFromScalar(d?: Uint8Array, compressed?: boolean): Uint8Array;
+  pointFromScalar(d: Uint8Array, compressed?: boolean): Uint8Array | null;
 
   sign(h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array;
   signSchnorr?(h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array;
@@ -167,8 +167,15 @@ export function ECPairFactory(ecc: TinySecp256k1Interface): ECPairAPI {
     }
 
     get publicKey(): Buffer {
-      if (!this.__Q)
-        this.__Q = Buffer.from(ecc.pointFromScalar(this.__D, this.compressed));
+      if (!this.__Q) {
+        // @ts-ignore: it is not possible for both `__Q` and `__D` to be `undefined` at the same time.
+        // The factory methods guard for this.
+        const p = ecc.pointFromScalar(this.__D, this.compressed);
+        // @ts-ignore: it is not possible for `p` to be null.
+        // `fromPrivateKey()` checks that `__D` is a valid scalar.
+        this.__Q = Buffer.from(p);
+      }
+
       return this.__Q;
     }
 

--- a/ts_src/ecpair.ts
+++ b/ts_src/ecpair.ts
@@ -168,10 +168,10 @@ export function ECPairFactory(ecc: TinySecp256k1Interface): ECPairAPI {
 
     get publicKey(): Buffer {
       if (!this.__Q) {
-        // @ts-ignore: it is not possible for both `__Q` and `__D` to be `undefined` at the same time.
+        // It is not possible for both `__Q` and `__D` to be `undefined` at the same time.
         // The factory methods guard for this.
-        const p = ecc.pointFromScalar(this.__D, this.compressed);
-        // @ts-ignore: it is not possible for `p` to be null.
+        const p = ecc.pointFromScalar(this.__D!, this.compressed)!;
+        // It is not possible for `p` to be null.
         // `fromPrivateKey()` checks that `__D` is a valid scalar.
         this.__Q = Buffer.from(p);
       }

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -6,4 +6,5 @@ export {
   ECPairAPI,
   ECPairInterface,
   TinySecp256k1Interface,
+  networks,
 } from './ecpair';


### PR DESCRIPTION
## Summary
 - make the `pointFromScalar()` method signature match exactly the one in `tiny-secp256k1`
    - otherwise the call `ECPairFactory(ecc)` will not compile
 - the fix adds two `@ts-ignore` with extra comments where `ecc.pointFromScalar()` is used