### PR TITLE
add `tweak()` method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2476,12 +2476,12 @@
       }
     },
     "tiny-secp256k1": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.1.2.tgz",
-      "integrity": "sha512-8qPw7zDK6Hco2tVGYGQeOmOPp/hZnREwy2iIkcq0ygAuqc9WHo29vKN94lNymh1QbB3nthtAMF6KTIrdbsIotA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.2.1.tgz",
+      "integrity": "sha512-/U4xfVqnVxJXN4YVsru0E6t5wVncu2uunB8+RVR40fYUxkKYUPS10f+ePQZgFBoE/Jbf9H1NBveupF2VmB58Ng==",
       "dev": true,
       "requires": {
-        "uint8array-tools": "0.0.6"
+        "uint8array-tools": "0.0.7"
       }
     },
     "to-fast-properties": {
@@ -2591,9 +2591,9 @@
       "dev": true
     },
     "uint8array-tools": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.6.tgz",
-      "integrity": "sha512-aIvEHNRX1AlOYAr6qSUjQBn4mCduxx6MtC967aRDTb2UUBPj0Ix2ZFQDcmXUUO/UxRPHcw1f5a5nVbCSKDSOqA==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.7.tgz",
+      "integrity": "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,6 +348,15 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@types/create-hash": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
+      "integrity": "sha512-Fg8/kfMJObbETFU/Tn+Y0jieYewryLrbKwLCEIwPyklZZVY2qB+64KFjhplGSw+cseZosfFXctXO+PyIYD8iZQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mocha": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
@@ -437,7 +446,7 @@
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
     },
     "arg": {
@@ -560,7 +569,7 @@
     "bs58": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
       "requires": {
         "base-x": "^3.0.2"
       }
@@ -584,7 +593,7 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "integrity": "sha512-wxXCdllwGhI2kCC0MnvTGYTMvnVZTvqgypkiTI8Pa5tcz2i6VqsqwYGgqwXji+4RgCzms6EajE4IxiUH6HH8nQ==",
       "dev": true
     },
     "caching-transform": {
@@ -725,7 +734,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "commander": {
@@ -737,13 +746,13 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "convert-source-map": {
@@ -823,7 +832,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "default-require-extensions": {
@@ -939,7 +948,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "esprima": {
@@ -951,7 +960,7 @@
     "fill-keys": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
       "dev": true,
       "requires": {
         "is-object": "~1.0.1",
@@ -1015,7 +1024,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -1129,7 +1138,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
     },
     "has-symbols": {
@@ -1188,7 +1197,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -1200,7 +1209,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -1284,13 +1293,13 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true
     },
     "is-glob": {
@@ -1372,7 +1381,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "is-weakref": {
@@ -1393,7 +1402,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -1579,7 +1588,7 @@
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "log-symbols": {
@@ -1627,13 +1636,13 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
     "minimaldata": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/minimaldata/-/minimaldata-1.0.2.tgz",
-      "integrity": "sha1-AfOywB2LJzmEP9hT1AY2xaLrdms=",
+      "integrity": "sha512-ZR9tWALR8ZszYd/zP34TmmVwRDVBNCT5+hkNXfTp3rpEDmZmgmYt1Sh/tu9qYFuPvSvEEEeJGE2BY8MBmeAzQQ==",
       "dev": true,
       "requires": {
         "bitcoin-ops": "^1.3.0",
@@ -1699,7 +1708,7 @@
     "module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
       "dev": true
     },
     "ms": {
@@ -1990,7 +1999,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -2044,13 +2053,13 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -2164,7 +2173,7 @@
     "pushdata-bitcoin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
-      "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
+      "integrity": "sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==",
       "dev": true,
       "requires": {
         "bitcoin-ops": "^1.3.0"
@@ -2200,7 +2209,7 @@
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
@@ -2209,7 +2218,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-main-filename": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "wif": "^2.0.6"
   },
   "devDependencies": {
+    "@types/create-hash": "^1.2.2",
     "@types/mocha": "^5.2.7",
     "@types/node": "^16.11.1",
     "@types/proxyquire": "^1.3.28",
@@ -62,6 +63,7 @@
     "bip68": "^1.0.3",
     "bn.js": "^4.11.8",
     "bs58": "^4.0.0",
+    "create-hash": "^1.2.0",
     "dhttp": "^3.0.0",
     "hoodwink": "^2.0.0",
     "minimaldata": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "prettier": "^2.4.1",
     "proxyquire": "^2.0.1",
     "rimraf": "^2.6.3",
-    "tiny-secp256k1": "^2.1.2",
+    "tiny-secp256k1": "^2.2.1",
     "ts-node": "^8.3.0",
     "tslint": "^6.1.3",
     "typescript": "^4.4.4"

--- a/src/ecpair.d.ts
+++ b/src/ecpair.d.ts
@@ -25,6 +25,7 @@ export interface ECPairInterface extends Signer {
     lowR: boolean;
     privateKey?: Buffer;
     toWIF(): string;
+    tweak(t: Buffer): ECPairInterface;
     verify(hash: Buffer, signature: Buffer): boolean;
     verifySchnorr(hash: Buffer, signature: Buffer): boolean;
     signSchnorr(hash: Buffer): Buffer;
@@ -41,9 +42,16 @@ export interface TinySecp256k1Interface {
     pointCompress(p: Uint8Array, compressed?: boolean): Uint8Array;
     isPrivate(d: Uint8Array): boolean;
     pointFromScalar(d: Uint8Array, compressed?: boolean): Uint8Array | null;
+    xOnlyPointAddTweak(p: Uint8Array, tweak: Uint8Array): XOnlyPointAddTweakResult | null;
+    privateAdd(d: Uint8Array, tweak: Uint8Array): Uint8Array | null;
+    privateNegate(d: Uint8Array): Uint8Array;
     sign(h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array;
     signSchnorr?(h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array;
     verify(h: Uint8Array, Q: Uint8Array, signature: Uint8Array, strict?: boolean): boolean;
     verifySchnorr?(h: Uint8Array, Q: Uint8Array, signature: Uint8Array): boolean;
+}
+export interface XOnlyPointAddTweakResult {
+    parity: 1 | 0;
+    xOnlyPubkey: Uint8Array;
 }
 export declare function ECPairFactory(ecc: TinySecp256k1Interface): ECPairAPI;

--- a/src/ecpair.d.ts
+++ b/src/ecpair.d.ts
@@ -50,7 +50,7 @@ export interface TinySecp256k1Interface {
     verify(h: Uint8Array, Q: Uint8Array, signature: Uint8Array, strict?: boolean): boolean;
     verifySchnorr?(h: Uint8Array, Q: Uint8Array, signature: Uint8Array): boolean;
 }
-export interface XOnlyPointAddTweakResult {
+interface XOnlyPointAddTweakResult {
     parity: 1 | 0;
     xOnlyPubkey: Uint8Array;
 }

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -100,8 +100,8 @@ function ECPairFactory(ecc) {
       return wif.encode(this.network.wif, this.__D, this.compressed);
     }
     tweak(t) {
-      if (!this.privateKey) return this.tweakFromPublicKey(t);
-      return this.tweakFromPrivateKey(t);
+      if (this.privateKey) return this.tweakFromPrivateKey(t);
+      return this.tweakFromPublicKey(t);
     }
     sign(hash, lowR) {
       if (!this.__D) throw new Error('Missing private key');

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -150,11 +150,12 @@ function ECPairFactory(ecc) {
       );
     }
     tweakFromPrivateKey(t) {
-      const parity = this.publicKey[0] === 4 && this.publicKey[64] & 1;
-      const privateKey =
-        this.publicKey[0] === 2 || parity === 0
-          ? this.privateKey
-          : ecc.privateNegate(this.privateKey);
+      const hasOddY =
+        this.publicKey[0] === 3 ||
+        (this.publicKey[0] === 4 && (this.publicKey[64] & 1) === 1);
+      const privateKey = hasOddY
+        ? ecc.privateNegate(this.privateKey)
+        : this.privateKey;
       const tweakedPrivateKey = ecc.privateAdd(privateKey, t);
       if (!tweakedPrivateKey) throw new Error('Invalid tweaked private key!');
       return fromPrivateKey(Buffer.from(tweakedPrivateKey), {

--- a/src/ecpair.js
+++ b/src/ecpair.js
@@ -13,6 +13,8 @@ const isOptions = types.typeforce.maybe(
     network: types.maybe(types.Network),
   }),
 );
+const toXOnly = (pubKey) =>
+  pubKey.length === 32 ? pubKey : pubKey.slice(1, 33);
 function ECPairFactory(ecc) {
   (0, testecc_1.testEcc)(ecc);
   function isPoint(maybePoint) {
@@ -97,6 +99,10 @@ function ECPairFactory(ecc) {
       if (!this.__D) throw new Error('Missing private key');
       return wif.encode(this.network.wif, this.__D, this.compressed);
     }
+    tweak(t) {
+      if (!this.privateKey) return this.tweakFromPublicKey(t);
+      return this.tweakFromPrivateKey(t);
+    }
     sign(hash, lowR) {
       if (!this.__D) throw new Error('Missing private key');
       if (lowR === undefined) lowR = this.lowR;
@@ -129,6 +135,32 @@ function ECPairFactory(ecc) {
       if (!ecc.verifySchnorr)
         throw new Error('verifySchnorr not supported by ecc library');
       return ecc.verifySchnorr(hash, this.publicKey.subarray(1, 33), signature);
+    }
+    tweakFromPublicKey(t) {
+      const xOnlyPubKey = toXOnly(this.publicKey);
+      const tweakedPublicKey = ecc.xOnlyPointAddTweak(xOnlyPubKey, t);
+      if (!tweakedPublicKey || tweakedPublicKey.xOnlyPubkey === null)
+        throw new Error('Cannot tweak public key!');
+      const parityByte = Buffer.from([
+        tweakedPublicKey.parity === 0 ? 0x02 : 0x03,
+      ]);
+      return fromPublicKey(
+        Buffer.concat([parityByte, tweakedPublicKey.xOnlyPubkey]),
+        { network: this.network, compressed: this.compressed },
+      );
+    }
+    tweakFromPrivateKey(t) {
+      const parity = this.publicKey[0] === 4 && this.publicKey[64] & 1;
+      const privateKey =
+        this.publicKey[0] === 2 || parity === 0
+          ? this.privateKey
+          : ecc.privateNegate(this.privateKey);
+      const tweakedPrivateKey = ecc.privateAdd(privateKey, t);
+      if (!tweakedPrivateKey) throw new Error('Invalid tweaked private key!');
+      return fromPrivateKey(Buffer.from(tweakedPrivateKey), {
+        network: this.network,
+        compressed: this.compressed,
+      });
     }
   }
   return {

--- a/src/testecc.js
+++ b/src/testecc.js
@@ -42,6 +42,61 @@ function testEcc(ecc) {
       h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142'),
     ),
   );
+  // 1 + 0 == 1
+  assert(
+    Buffer.from(
+      ecc.privateAdd(
+        h('0000000000000000000000000000000000000000000000000000000000000001'),
+        h('0000000000000000000000000000000000000000000000000000000000000000'),
+      ),
+    ).equals(
+      h('0000000000000000000000000000000000000000000000000000000000000001'),
+    ),
+  );
+  // -3 + 3 == 0
+  assert(
+    ecc.privateAdd(
+      h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'),
+      h('0000000000000000000000000000000000000000000000000000000000000003'),
+    ) === null,
+  );
+  assert(
+    Buffer.from(
+      ecc.privateAdd(
+        h('e211078564db65c3ce7704f08262b1f38f1ef412ad15b5ac2d76657a63b2c500'),
+        h('b51fbb69051255d1becbd683de5848242a89c229348dd72896a87ada94ae8665'),
+      ),
+    ).equals(
+      h('9730c2ee69edbb958d42db7460bafa18fef9d955325aec99044c81c8282b0a24'),
+    ),
+  );
+  assert(
+    Buffer.from(
+      ecc.privateNegate(
+        h('0000000000000000000000000000000000000000000000000000000000000001'),
+      ),
+    ).equals(
+      h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
+    ),
+  );
+  assert(
+    Buffer.from(
+      ecc.privateNegate(
+        h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'),
+      ),
+    ).equals(
+      h('0000000000000000000000000000000000000000000000000000000000000003'),
+    ),
+  );
+  assert(
+    Buffer.from(
+      ecc.privateNegate(
+        h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
+      ),
+    ).equals(
+      h('4eede1bf775995d70a494f0a7bb6bc11e0b8cccd41cce8009ab1132c8b0a3792'),
+    ),
+  );
   assert(
     Buffer.from(
       ecc.pointCompress(
@@ -98,6 +153,30 @@ function testEcc(ecc) {
     ).equals(
       h('02b07ba9dca9523b7ef4bd97703d43d20399eb698e194704791a25ce77a400df99'),
     ),
+  );
+  assert(
+    ecc.xOnlyPointAddTweak(
+      h('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
+      h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
+    ) === null,
+  );
+  let xOnlyRes = ecc.xOnlyPointAddTweak(
+    h('1617d38ed8d8657da4d4761e8057bc396ea9e4b9d29776d4be096016dbd2509b'),
+    h('a8397a935f0dfceba6ba9618f6451ef4d80637abf4e6af2669fbc9de6a8fd2ac'),
+  );
+  assert(
+    Buffer.from(xOnlyRes.xOnlyPubkey).equals(
+      h('e478f99dab91052ab39a33ea35fd5e6e4933f4d28023cd597c9a1f6760346adf'),
+    ) && xOnlyRes.parity === 1,
+  );
+  xOnlyRes = ecc.xOnlyPointAddTweak(
+    h('2c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991'),
+    h('823c3cd2142744b075a87eade7e1b8678ba308d566226a0056ca2b7a76f86b47'),
+  );
+  assert(
+    Buffer.from(xOnlyRes.xOnlyPubkey).equals(
+      h('9534f8dc8c6deda2dc007655981c78b49c5d96c778fbf363462a11ec9dfd948c'),
+    ) && xOnlyRes.parity === 0,
   );
   assert(
     Buffer.from(

--- a/test/fixtures/ecpair.json
+++ b/test/fixtures/ecpair.json
@@ -6,7 +6,8 @@
       "compressed": true,
       "network": "bitcoin",
       "address": "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-      "WIF": "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn"
+      "WIF": "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn",
+      "tweak":  "KyGComs4RrHnqnn5ku3WxA6CVFmHJV61bm8V36Uu4WMsRjjdeAVr"
     },
     {
       "d": "0000000000000000000000000000000000000000000000000000000000000001",
@@ -14,7 +15,8 @@
       "compressed": false,
       "network": "bitcoin",
       "address": "1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm",
-      "WIF": "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf"
+      "WIF": "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf",
+      "tweak":  "5JH8fEnnBcdtAhH74buE8WhbmvBwSiFjH2qpb1LTkPWehzrbBaF"
     },
     {
       "d": "2bfe58ab6d9fd575bdc3a624e4825dd2b375d64ac033fbc46ea79dbab4f69a3e",
@@ -22,7 +24,8 @@
       "compressed": true,
       "network": "bitcoin",
       "address": "1MasfEKgSiaSeri2C6kgznaqBNtyrZPhNq",
-      "WIF": "KxhEDBQyyEFymvfJD96q8stMbJMbZUb6D1PmXqBWZDU2WvbvVs9o"
+      "WIF": "KxhEDBQyyEFymvfJD96q8stMbJMbZUb6D1PmXqBWZDU2WvbvVs9o",
+      "tweak":  "KwUyUow4TNzozBuaxR5VAQRw99PFQqYZXFn5ZN7Cm2FPeRvXwoAD"
     },
     {
       "d": "6c4313b03f2e7324d75e642f0ab81b734b724e13fec930f309e222470236d66b",
@@ -30,7 +33,8 @@
       "compressed": true,
       "network": "bitcoin",
       "address": "1LwwMWdSEMHJ2dMhSvAHZ3g95tG2UBv9jg",
-      "WIF": "KzrA86mCVMGWnLGBQu9yzQa32qbxb5dvSK4XhyjjGAWSBKYX4rHx"
+      "WIF": "KzrA86mCVMGWnLGBQu9yzQa32qbxb5dvSK4XhyjjGAWSBKYX4rHx",
+      "tweak":  "L4LVynF3Ra6tpU14rMjx2bjNTbKpathPA1KcKVch8UpuGJgHakpw"
     },
     {
       "d": "6c4313b03f2e7324d75e642f0ab81b734b724e13fec930f309e222470236d66b",
@@ -38,7 +42,8 @@
       "compressed": false,
       "network": "bitcoin",
       "address": "1zXcfvKCLgsFdJDYPuqpu1sF3q92tnnUM",
-      "WIF": "5JdxzLtFPHNe7CAL8EBC6krdFv9pwPoRo4e3syMZEQT9srmK8hh"
+      "WIF": "5JdxzLtFPHNe7CAL8EBC6krdFv9pwPoRo4e3syMZEQT9srmK8hh",
+      "tweak":  "5KRotqK8oMBrMGdievBdwHUj23Lfsj5AYwuFM3rmtYE7rmwTEsf"
     },
     {
       "d": "6c4313b03f2e7324d75e642f0ab81b734b724e13fec930f309e222470236d66b",
@@ -46,7 +51,8 @@
       "compressed": true,
       "network": "testnet",
       "address": "n1TteZiR3NiYojqKAV8fNxtTwsrjM7kVdj",
-      "WIF": "cRD9b1m3vQxmwmjSoJy7Mj56f4uNFXjcWMCzpQCEmHASS4edEwXv"
+      "WIF": "cRD9b1m3vQxmwmjSoJy7Mj56f4uNFXjcWMCzpQCEmHASS4edEwXv",
+      "tweak":  "cUhVShEtrdo9yuULEmZ5PvES5pdEFLo5E3U5Rv5CdbUuX3pgcvk2"
     },
     {
       "d": "6c4313b03f2e7324d75e642f0ab81b734b724e13fec930f309e222470236d66b",
@@ -54,7 +60,8 @@
       "compressed": false,
       "network": "testnet",
       "address": "mgWUuj1J1N882jmqFxtDepEC73Rr22E9GU",
-      "WIF": "92Qba5hnyWSn5Ffcka56yMQauaWY6ZLd91Vzxbi4a9CCetaHtYj"
+      "WIF": "92Qba5hnyWSn5Ffcka56yMQauaWY6ZLd91Vzxbi4a9CCetaHtYj",
+      "tweak":  "93CSUa8gPaFzKL91HG5Yot2gfhhP2tcMttmCRgDHEGyAdoiN1CE"
     },
     {
       "d": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
@@ -62,7 +69,8 @@
       "compressed": true,
       "network": "bitcoin",
       "address": "1GrLCmVQXoyJXaPJQdqssNqwxvha1eUo2E",
-      "WIF": "L5oLkpV3aqBjhki6LmvChTCV6odsp4SXM6FfU2Gppt5kFLaHLuZ9"
+      "WIF": "L5oLkpV3aqBjhki6LmvChTCV6odsp4SXM6FfU2Gppt5kFLaHLuZ9",
+      "tweak":  "KyGComs4RrHnqnn5ku3WxA6CVFmHJV61bm8V36Uu4WMsRjjdeAVr"
     }
   ],
   "invalid": {

--- a/ts_src/ecpair.ts
+++ b/ts_src/ecpair.ts
@@ -257,11 +257,12 @@ export function ECPairFactory(ecc: TinySecp256k1Interface): ECPairAPI {
     }
 
     private tweakFromPrivateKey(t: Buffer): ECPairInterface {
-      const parity = this.publicKey[0] === 4 && this.publicKey[64] & 1;
-      const privateKey =
-        this.publicKey[0] === 2 || parity === 0
-          ? this.privateKey
-          : ecc.privateNegate(this.privateKey!);
+      const hasOddY =
+        this.publicKey[0] === 3 ||
+        (this.publicKey[0] === 4 && (this.publicKey[64] & 1) === 1);
+      const privateKey = hasOddY
+        ? ecc.privateNegate(this.privateKey!)
+        : this.privateKey;
 
       const tweakedPrivateKey = ecc.privateAdd(privateKey!, t);
       if (!tweakedPrivateKey) throw new Error('Invalid tweaked private key!');

--- a/ts_src/ecpair.ts
+++ b/ts_src/ecpair.ts
@@ -81,7 +81,7 @@ export interface TinySecp256k1Interface {
   verifySchnorr?(h: Uint8Array, Q: Uint8Array, signature: Uint8Array): boolean;
 }
 
-export interface XOnlyPointAddTweakResult {
+interface XOnlyPointAddTweakResult {
   parity: 1 | 0;
   xOnlyPubkey: Uint8Array;
 }

--- a/ts_src/ecpair.ts
+++ b/ts_src/ecpair.ts
@@ -201,8 +201,8 @@ export function ECPairFactory(ecc: TinySecp256k1Interface): ECPairAPI {
     }
 
     tweak(t: Buffer): ECPairInterface {
-      if (!this.privateKey) return this.tweakFromPublicKey(t);
-      return this.tweakFromPrivateKey(t);
+      if (this.privateKey) return this.tweakFromPrivateKey(t);
+      return this.tweakFromPublicKey(t);
     }
 
     sign(hash: Buffer, lowR?: boolean): Buffer {

--- a/ts_src/testecc.ts
+++ b/ts_src/testecc.ts
@@ -42,6 +42,61 @@ export function testEcc(ecc: TinySecp256k1Interface): void {
       h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142'),
     ),
   );
+  // 1 + 0 == 1
+  assert(
+    Buffer.from(
+      ecc.privateAdd(
+        h('0000000000000000000000000000000000000000000000000000000000000001'),
+        h('0000000000000000000000000000000000000000000000000000000000000000'),
+      )!,
+    ).equals(
+      h('0000000000000000000000000000000000000000000000000000000000000001'),
+    ),
+  );
+  // -3 + 3 == 0
+  assert(
+    ecc.privateAdd(
+      h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'),
+      h('0000000000000000000000000000000000000000000000000000000000000003'),
+    ) === null,
+  );
+  assert(
+    Buffer.from(
+      ecc.privateAdd(
+        h('e211078564db65c3ce7704f08262b1f38f1ef412ad15b5ac2d76657a63b2c500'),
+        h('b51fbb69051255d1becbd683de5848242a89c229348dd72896a87ada94ae8665'),
+      )!,
+    ).equals(
+      h('9730c2ee69edbb958d42db7460bafa18fef9d955325aec99044c81c8282b0a24'),
+    ),
+  );
+  assert(
+    Buffer.from(
+      ecc.privateNegate(
+        h('0000000000000000000000000000000000000000000000000000000000000001'),
+      ),
+    ).equals(
+      h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
+    ),
+  );
+  assert(
+    Buffer.from(
+      ecc.privateNegate(
+        h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'),
+      ),
+    ).equals(
+      h('0000000000000000000000000000000000000000000000000000000000000003'),
+    ),
+  );
+  assert(
+    Buffer.from(
+      ecc.privateNegate(
+        h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
+      ),
+    ).equals(
+      h('4eede1bf775995d70a494f0a7bb6bc11e0b8cccd41cce8009ab1132c8b0a3792'),
+    ),
+  );
   assert(
     Buffer.from(
       ecc.pointCompress(
@@ -99,6 +154,34 @@ export function testEcc(ecc: TinySecp256k1Interface): void {
       h('02b07ba9dca9523b7ef4bd97703d43d20399eb698e194704791a25ce77a400df99'),
     ),
   );
+
+  assert(
+    ecc.xOnlyPointAddTweak(
+      h('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
+      h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
+    ) === null,
+  );
+
+  let xOnlyRes = ecc.xOnlyPointAddTweak(
+    h('1617d38ed8d8657da4d4761e8057bc396ea9e4b9d29776d4be096016dbd2509b'),
+    h('a8397a935f0dfceba6ba9618f6451ef4d80637abf4e6af2669fbc9de6a8fd2ac'),
+  );
+  assert(
+    Buffer.from(xOnlyRes!.xOnlyPubkey).equals(
+      h('e478f99dab91052ab39a33ea35fd5e6e4933f4d28023cd597c9a1f6760346adf'),
+    ) && xOnlyRes!.parity === 1,
+  );
+
+  xOnlyRes = ecc.xOnlyPointAddTweak(
+    h('2c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991'),
+    h('823c3cd2142744b075a87eade7e1b8678ba308d566226a0056ca2b7a76f86b47'),
+  );
+  assert(
+    Buffer.from(xOnlyRes!.xOnlyPubkey).equals(
+      h('9534f8dc8c6deda2dc007655981c78b49c5d96c778fbf363462a11ec9dfd948c'),
+    ) && xOnlyRes!.parity === 0,
+  );
+
   assert(
     Buffer.from(
       ecc.sign(


### PR DESCRIPTION
This is a follow up from this [deprecated PR](https://github.com/bitcoinjs/ecpair/pull/6#issuecomment-1143745140)

Add the `tweak(t: Buffer): ECPairInterface;` method to `ECPairInterface`

It can tweak a `keyPair` that has a `privateKey`, and also a keyPair where only the `publicKey` is present.

The unit tests use the `tapTweakHash()` function to create the tweak hash. This has several benefits:
 - a deterministic way to produces the hash
 - do not pollute the fixtures with the tweak value
 - could (manually) check against regtest that the tweak is fine