### PR TITLE
fix: include file extension for relative paths in ESM

### DIFF
--- a/src/esm/ecpair.js
+++ b/src/esm/ecpair.js
@@ -1,7 +1,7 @@
-import * as networks from './networks';
-import * as types from './types';
+import * as networks from './networks.js';
+import * as types from './types.js';
 import * as wif from 'wif';
-import { testEcc } from './testecc';
+import { testEcc } from './testecc.js';
 export { networks };
 import * as v from 'valibot';
 import * as tools from 'uint8array-tools';

--- a/src/esm/index.js
+++ b/src/esm/index.js
@@ -1,1 +1,1 @@
-export { ECPairFactory as default, ECPairFactory, networks } from './ecpair';
+export { ECPairFactory as default, ECPairFactory, networks } from './ecpair.js';


### PR DESCRIPTION
This PR includes `.js` extensions over relative paths in `import`s 

See [NodeJS official docs on mandatory .js extensions for relative paths when using ESM](https://nodejs.org/api/esm.html#mandatory-file-extensions)

Minor change, but this allows non-TSX/ts-node environments to properly import this code. 

I encountered this issue while handling some tests with `vitest`. I can provide a reproducible environment, but it should be as small as creating a test and importing this code. 

Notice that this is fixed on [tiny-secp256k1](https://github.com/bitcoinjs/tiny-secp256k1/blob/master/tests/index.js#L5)
