### PR TITLE
Avoid Buffer in testEcc

### DIFF
--- a/src/cjs/testecc.cjs
+++ b/src/cjs/testecc.cjs
@@ -1,7 +1,9 @@
 'use strict';
 Object.defineProperty(exports, '__esModule', { value: true });
 exports.testEcc = testEcc;
-const h = (hex) => Buffer.from(hex, 'hex');
+const uint8array_tools_1 = require('uint8array-tools');
+const h = (hex) => (0, uint8array_tools_1.fromHex)(hex);
+const eq = (a, b) => (0, uint8array_tools_1.compare)(a, b) === 0;
 function testEcc(ecc) {
   assert(
     ecc.isPoint(
@@ -44,12 +46,11 @@ function testEcc(ecc) {
   );
   // 1 + 0 == 1
   assert(
-    Buffer.from(
+    eq(
       ecc.privateAdd(
         h('0000000000000000000000000000000000000000000000000000000000000001'),
         h('0000000000000000000000000000000000000000000000000000000000000000'),
       ),
-    ).equals(
       h('0000000000000000000000000000000000000000000000000000000000000001'),
     ),
   );
@@ -61,96 +62,87 @@ function testEcc(ecc) {
     ) === null,
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateAdd(
         h('e211078564db65c3ce7704f08262b1f38f1ef412ad15b5ac2d76657a63b2c500'),
         h('b51fbb69051255d1becbd683de5848242a89c229348dd72896a87ada94ae8665'),
       ),
-    ).equals(
       h('9730c2ee69edbb958d42db7460bafa18fef9d955325aec99044c81c8282b0a24'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateNegate(
         h('0000000000000000000000000000000000000000000000000000000000000001'),
       ),
-    ).equals(
       h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateNegate(
         h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'),
       ),
-    ).equals(
       h('0000000000000000000000000000000000000000000000000000000000000003'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateNegate(
         h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
       ),
-    ).equals(
       h('4eede1bf775995d70a494f0a7bb6bc11e0b8cccd41cce8009ab1132c8b0a3792'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h(
           '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
         ),
         true,
       ),
-    ).equals(
       h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h(
           '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
         ),
         false,
       ),
-    ).equals(
       h(
         '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
       ),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
         true,
       ),
-    ).equals(
       h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
         false,
       ),
-    ).equals(
       h(
         '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
       ),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointFromScalar(
         h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
       ),
-    ).equals(
       h('02b07ba9dca9523b7ef4bd97703d43d20399eb698e194704791a25ce77a400df99'),
     ),
   );
@@ -165,7 +157,8 @@ function testEcc(ecc) {
     h('a8397a935f0dfceba6ba9618f6451ef4d80637abf4e6af2669fbc9de6a8fd2ac'),
   );
   assert(
-    Buffer.from(xOnlyRes.xOnlyPubkey).equals(
+    eq(
+      xOnlyRes.xOnlyPubkey,
       h('e478f99dab91052ab39a33ea35fd5e6e4933f4d28023cd597c9a1f6760346adf'),
     ) && xOnlyRes.parity === 1,
   );
@@ -174,17 +167,17 @@ function testEcc(ecc) {
     h('823c3cd2142744b075a87eade7e1b8678ba308d566226a0056ca2b7a76f86b47'),
   );
   assert(
-    Buffer.from(xOnlyRes.xOnlyPubkey).equals(
+    eq(
+      xOnlyRes.xOnlyPubkey,
       h('9534f8dc8c6deda2dc007655981c78b49c5d96c778fbf363462a11ec9dfd948c'),
     ) && xOnlyRes.parity === 0,
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.sign(
         h('5e9f0a0d593efdcf78ac923bc3313e4e7d408d574354ee2b3288c0da9fbba6ed'),
         h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
       ),
-    ).equals(
       h(
         '54c4a33c6423d689378f160a7ff8b61330444abb58fb470f96ea16d99d4a2fed07082304410efa6b2943111b6a4e0aaa7b7db55a07e9861d1fb3cb1f421044a5',
       ),
@@ -201,13 +194,12 @@ function testEcc(ecc) {
   );
   if (ecc.signSchnorr) {
     assert(
-      Buffer.from(
+      eq(
         ecc.signSchnorr(
           h('7e2d58d8b3bcdf1abadec7829054f90dda9805aab56c77333024b9d0a508b75c'),
           h('c90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74020bbea63b14e5c9'),
           h('c87aa53824b4d7ae2eb035a2b5bbbccc080e76cdc6d1692c4b0b62d798e6d906'),
         ),
-      ).equals(
         h(
           '5831aaeed7b44bb74e5eab94ba9d4294c49bcf2a60728d8b4c200f50dd313c1bab745879a5ad954a72c45a91c3a51d3c7adea98d82f8481e0e1e03674a6f3fb7',
         ),

--- a/src/esm/testecc.js
+++ b/src/esm/testecc.js
@@ -1,4 +1,6 @@
-const h = (hex) => Buffer.from(hex, 'hex');
+import { compare, fromHex } from 'uint8array-tools';
+const h = (hex) => fromHex(hex);
+const eq = (a, b) => compare(a, b) === 0;
 export function testEcc(ecc) {
   assert(
     ecc.isPoint(
@@ -41,12 +43,11 @@ export function testEcc(ecc) {
   );
   // 1 + 0 == 1
   assert(
-    Buffer.from(
+    eq(
       ecc.privateAdd(
         h('0000000000000000000000000000000000000000000000000000000000000001'),
         h('0000000000000000000000000000000000000000000000000000000000000000'),
       ),
-    ).equals(
       h('0000000000000000000000000000000000000000000000000000000000000001'),
     ),
   );
@@ -58,96 +59,87 @@ export function testEcc(ecc) {
     ) === null,
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateAdd(
         h('e211078564db65c3ce7704f08262b1f38f1ef412ad15b5ac2d76657a63b2c500'),
         h('b51fbb69051255d1becbd683de5848242a89c229348dd72896a87ada94ae8665'),
       ),
-    ).equals(
       h('9730c2ee69edbb958d42db7460bafa18fef9d955325aec99044c81c8282b0a24'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateNegate(
         h('0000000000000000000000000000000000000000000000000000000000000001'),
       ),
-    ).equals(
       h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateNegate(
         h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'),
       ),
-    ).equals(
       h('0000000000000000000000000000000000000000000000000000000000000003'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateNegate(
         h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
       ),
-    ).equals(
       h('4eede1bf775995d70a494f0a7bb6bc11e0b8cccd41cce8009ab1132c8b0a3792'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h(
           '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
         ),
         true,
       ),
-    ).equals(
       h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h(
           '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
         ),
         false,
       ),
-    ).equals(
       h(
         '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
       ),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
         true,
       ),
-    ).equals(
       h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
         false,
       ),
-    ).equals(
       h(
         '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
       ),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointFromScalar(
         h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
       ),
-    ).equals(
       h('02b07ba9dca9523b7ef4bd97703d43d20399eb698e194704791a25ce77a400df99'),
     ),
   );
@@ -162,7 +154,8 @@ export function testEcc(ecc) {
     h('a8397a935f0dfceba6ba9618f6451ef4d80637abf4e6af2669fbc9de6a8fd2ac'),
   );
   assert(
-    Buffer.from(xOnlyRes.xOnlyPubkey).equals(
+    eq(
+      xOnlyRes.xOnlyPubkey,
       h('e478f99dab91052ab39a33ea35fd5e6e4933f4d28023cd597c9a1f6760346adf'),
     ) && xOnlyRes.parity === 1,
   );
@@ -171,17 +164,17 @@ export function testEcc(ecc) {
     h('823c3cd2142744b075a87eade7e1b8678ba308d566226a0056ca2b7a76f86b47'),
   );
   assert(
-    Buffer.from(xOnlyRes.xOnlyPubkey).equals(
+    eq(
+      xOnlyRes.xOnlyPubkey,
       h('9534f8dc8c6deda2dc007655981c78b49c5d96c778fbf363462a11ec9dfd948c'),
     ) && xOnlyRes.parity === 0,
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.sign(
         h('5e9f0a0d593efdcf78ac923bc3313e4e7d408d574354ee2b3288c0da9fbba6ed'),
         h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
       ),
-    ).equals(
       h(
         '54c4a33c6423d689378f160a7ff8b61330444abb58fb470f96ea16d99d4a2fed07082304410efa6b2943111b6a4e0aaa7b7db55a07e9861d1fb3cb1f421044a5',
       ),
@@ -198,13 +191,12 @@ export function testEcc(ecc) {
   );
   if (ecc.signSchnorr) {
     assert(
-      Buffer.from(
+      eq(
         ecc.signSchnorr(
           h('7e2d58d8b3bcdf1abadec7829054f90dda9805aab56c77333024b9d0a508b75c'),
           h('c90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74020bbea63b14e5c9'),
           h('c87aa53824b4d7ae2eb035a2b5bbbccc080e76cdc6d1692c4b0b62d798e6d906'),
         ),
-      ).equals(
         h(
           '5831aaeed7b44bb74e5eab94ba9d4294c49bcf2a60728d8b4c200f50dd313c1bab745879a5ad954a72c45a91c3a51d3c7adea98d82f8481e0e1e03674a6f3fb7',
         ),

--- a/ts_src/testecc.ts
+++ b/ts_src/testecc.ts
@@ -1,6 +1,8 @@
 import { TinySecp256k1Interface } from './ecpair';
+import { compare, fromHex } from 'uint8array-tools';
 
-const h = (hex: string): Buffer => Buffer.from(hex, 'hex');
+const h = (hex: string): Uint8Array => fromHex(hex);
+const eq = (a: Uint8Array, b: Uint8Array): boolean => compare(a, b) === 0;
 
 export function testEcc(ecc: TinySecp256k1Interface): void {
   assert(
@@ -44,12 +46,11 @@ export function testEcc(ecc: TinySecp256k1Interface): void {
   );
   // 1 + 0 == 1
   assert(
-    Buffer.from(
+    eq(
       ecc.privateAdd(
         h('0000000000000000000000000000000000000000000000000000000000000001'),
         h('0000000000000000000000000000000000000000000000000000000000000000'),
       )!,
-    ).equals(
       h('0000000000000000000000000000000000000000000000000000000000000001'),
     ),
   );
@@ -61,96 +62,87 @@ export function testEcc(ecc: TinySecp256k1Interface): void {
     ) === null,
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateAdd(
         h('e211078564db65c3ce7704f08262b1f38f1ef412ad15b5ac2d76657a63b2c500'),
         h('b51fbb69051255d1becbd683de5848242a89c229348dd72896a87ada94ae8665'),
       )!,
-    ).equals(
       h('9730c2ee69edbb958d42db7460bafa18fef9d955325aec99044c81c8282b0a24'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateNegate(
         h('0000000000000000000000000000000000000000000000000000000000000001'),
       ),
-    ).equals(
       h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateNegate(
         h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e'),
       ),
-    ).equals(
       h('0000000000000000000000000000000000000000000000000000000000000003'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.privateNegate(
         h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
       ),
-    ).equals(
       h('4eede1bf775995d70a494f0a7bb6bc11e0b8cccd41cce8009ab1132c8b0a3792'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h(
           '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
         ),
         true,
       )!,
-    ).equals(
       h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h(
           '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
         ),
         false,
       )!,
-    ).equals(
       h(
         '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
       ),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
         true,
       )!,
-    ).equals(
       h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointCompress(
         h('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798'),
         false,
       )!,
-    ).equals(
       h(
         '0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8',
       ),
     ),
   );
   assert(
-    Buffer.from(
+    eq(
       ecc.pointFromScalar(
         h('b1121e4088a66a28f5b6b0f5844943ecd9f610196d7bb83b25214b60452c09af'),
       )!,
-    ).equals(
       h('02b07ba9dca9523b7ef4bd97703d43d20399eb698e194704791a25ce77a400df99'),
     ),
   );
@@ -167,7 +159,8 @@ export function testEcc(ecc: TinySecp256k1Interface): void {
     h('a8397a935f0dfceba6ba9618f6451ef4d80637abf4e6af2669fbc9de6a8fd2ac'),
   );
   assert(
-    Buffer.from(xOnlyRes!.xOnlyPubkey).equals(
+    eq(
+      xOnlyRes!.xOnlyPubkey,
       h('e478f99dab91052ab39a33ea35fd5e6e4933f4d28023cd597c9a1f6760346adf'),
     ) && xOnlyRes!.parity === 1,
   );
@@ -177,18 +170,18 @@ export function testEcc(ecc: TinySecp256k1Interface): void {
     h('823c3cd2142744b075a87eade7e1b8678ba308d566226a0056ca2b7a76f86b47'),
   );
   assert(
-    Buffer.from(xOnlyRes!.xOnlyPubkey).equals(
+    eq(
+      xOnlyRes!.xOnlyPubkey,
       h('9534f8dc8c6deda2dc007655981c78b49c5d96c778fbf363462a11ec9dfd948c'),
     ) && xOnlyRes!.parity === 0,
   );
 
   assert(
-    Buffer.from(
+    eq(
       ecc.sign(
         h('5e9f0a0d593efdcf78ac923bc3313e4e7d408d574354ee2b3288c0da9fbba6ed'),
         h('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140'),
       )!,
-    ).equals(
       h(
         '54c4a33c6423d689378f160a7ff8b61330444abb58fb470f96ea16d99d4a2fed07082304410efa6b2943111b6a4e0aaa7b7db55a07e9861d1fb3cb1f421044a5',
       ),
@@ -205,13 +198,12 @@ export function testEcc(ecc: TinySecp256k1Interface): void {
   );
   if (ecc.signSchnorr) {
     assert(
-      Buffer.from(
+      eq(
         ecc.signSchnorr(
           h('7e2d58d8b3bcdf1abadec7829054f90dda9805aab56c77333024b9d0a508b75c'),
           h('c90fdaa22168c234c4c6628b80dc1cd129024e088a67cc74020bbea63b14e5c9'),
           h('c87aa53824b4d7ae2eb035a2b5bbbccc080e76cdc6d1692c4b0b62d798e6d906'),
         )!,
-      ).equals(
         h(
           '5831aaeed7b44bb74e5eab94ba9d4294c49bcf2a60728d8b4c200f50dd313c1bab745879a5ad954a72c45a91c3a51d3c7adea98d82f8481e0e1e03674a6f3fb7',
         ),


### PR DESCRIPTION
PR #22 moved ecpair toward Uint8Array and away from Buffer, but testEcc still used Buffer for hex vectors and equality checks. This replaces those leftovers with uint8array-tools so testEcc no longer needs Buffer or Buffer polyfills. Tests: npm test